### PR TITLE
Add MacOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ This script prepares most parts of a new ClassicPress release.
 
 ## How to use
 
-**You must be running Linux**. This script will not work with OS X as it is
-currently written due to usage of `grep -P`, `sed -r`, and perhaps other
-commands/flags.
+**This script supports Linux and MacOS**. To work with MacOS it is recommended to use
+[Homebrew](https://brew.sh/) and necessary to install `gnu-sed` .
 
 You'll need the following programs installed on your computer:
 
@@ -15,6 +14,7 @@ You'll need the following programs installed on your computer:
 - `convert` (part of https://imagemagick.org/)
 - `git flow`: https://github.com/petervanderdoes/gitflow-avh ([Homebrew](https://formulae.brew.sh/formula/git-flow-avh))
 - `gpg`
+- `gnu-sed`: https://formulae.brew.sh/formula/gnu-sed (**MacOS only**)
 
 Copy `sample-config.sh` to `config.sh` and fill in the values.  In order to do
 an official ClassicPress release, you'll need the correct key registered with

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -64,7 +64,7 @@ for v in \
 	fi
 done
 
-for p in git nvm convert; do
+for p in git nvm convert $SED_COMMAND; do
 	if ! type -t $p > /dev/null; then
 		echo "Program/function \`$p\` not found, make sure it is installed!" >&2
 		exit 1

--- a/sample-config.sh
+++ b/sample-config.sh
@@ -10,4 +10,4 @@ CP_RELEASE_PATH="$HOME/cp/ClassicPress-release"
 GPG_KEY_ID="ABCD1234"
 
 # The subforum where the release draft should be posted
-DRAFT_SUBFORUM_URL="https://forums.classicpress.net/c/internal/scheduled-topics"
+DRAFT_SUBFORUM_URL="https://forums.classicpress.net/c/meta/scheduled-topics"


### PR DESCRIPTION
- Update `grep` expressions to use `-E` in favour of `-P` for MacOS compatibility, will need compliance testing on linux.
- Add step to use appropriate `sed` command variant on MacOS
- Add a check for the used `sed` command variant