### PR TITLE
Update package-lock.json during release process

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -234,6 +234,11 @@ wait_cmd 'dev-version-bump-package-json' \
 	"s#^(\s+\"version\": )\"[^\"]+\",\$#\\1\"$VERSION+dev\",#" \
 	package.json
 
+wait_cmd 'dev-version-bump-package-lock-json' \
+	$SED_COMMAND -ri \
+	"s#^(\s+\"version\": )\"[^\"]+(\+dev\"),\$#\\1\"$VERSION\2\,#" \
+	package-lock.json
+
 wait_cmd 'dev-version-bump-version-php' \
 	$SED_COMMAND -ri \
 	"s#^(\\\$cp_version = )'[^\']+';\$#\\1'$VERSION+dev';#" \
@@ -242,11 +247,11 @@ wait_cmd 'dev-version-bump-version-php' \
 git diff
 wait_action 'dev-version-inspect' \
 	"inspect above output:" \
-	"verify version updated to '$VERSION+dev' in package.json and version.php" \
+	"verify version updated to '$VERSION+dev' in package.json, package-lock.json and version.php" \
 	"with no other changes"
 
 wait_cmd 'dev-version-git-add' \
-	git add package.json src/wp-includes/version.php
+	git add package.json package-lock.json src/wp-includes/version.php
 
 wait_cmd 'dev-version-git-commit' \
 	git commit -m "Bump source version to $VERSION+dev"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -293,7 +293,7 @@ wait_cmd 'dev-nvm-use' \
 wait_cmd 'dev-npm-install' \
 	npm install
 wait_cmd 'dev-npm-install-grunt' \
-	npm install -g grunt-cli
+	npm list grunt-cli || npm install -g grunt-cli
 wait_cmd 'release-build' \
 	CLASSICPRESS_RELEASE=true grunt build
 


### PR DESCRIPTION
This PR introduces a step to the build script that updated the ClassicPress version number in the `package-lock.json` file.

The script currently updates `packeage.json` and `wp-includes/version.php` but package-lock.json is not updated. It seems it updates as part of Renovate PRs to dependencies later. But we should not rely on Renovate PRs for this step.

The Regex needs thorough checking before this is merge.