### PR TITLE
Update magick convert step

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -195,7 +195,7 @@ wait_input() {
 wait_cmd \
 	"[[release-banner: images/ClassicPress-release-banner-v$VERSION.png]]" \
 	'release-banner' \
-	convert images/ClassicPress-release-banner-template.png \
+	magick convert images/ClassicPress-release-banner-template.png \
 	-font images/source-sans-pro/SourceSansPro-Regular.otf \
 	-pointsize 90 \
 	-fill 'rgb(255,255,255)' \

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -195,7 +195,7 @@ wait_input() {
 wait_cmd \
 	"[[release-banner: images/ClassicPress-release-banner-v$VERSION.png]]" \
 	'release-banner' \
-	magick convert images/ClassicPress-release-banner-template.png \
+	magick images/ClassicPress-release-banner-template.png \
 	-font images/source-sans-pro/SourceSansPro-Regular.otf \
 	-pointsize 90 \
 	-fill 'rgb(255,255,255)' \


### PR DESCRIPTION
The image creation step is showing a deprecation notice locally during builds, this change addresses the deprecation notice.

Before:
![Screenshot 2025-01-02 at 17 25 44](https://github.com/user-attachments/assets/811ad9fb-4f59-4970-a1e4-188379e9b16c)

After:
![Screenshot 2025-01-02 at 17 25 31](https://github.com/user-attachments/assets/5566c184-769a-466c-8f9b-a4cdc84d0f9b)
